### PR TITLE
Fix crash when hide default settings is enabled

### DIFF
--- a/src/plugins/betterScreenshare.desktop/patches/screenshareModal.tsx
+++ b/src/plugins/betterScreenshare.desktop/patches/screenshareModal.tsx
@@ -63,7 +63,7 @@ export function replacedScreenshareModalSettingsContentType(oldType: (...args: a
     const oldTypeResult = Reflect.apply(oldType, thisContext, functionArguments);
 
     if (hideDefaultSettings)
-        oldTypeResult.props.children = oldTypeResult.props.children.filter(c => !c?.props.selectedFPS);
+        oldTypeResult.props.children = oldTypeResult.props.children.filter(c => !c?.props?.selectedFPS);
     oldTypeResult.props.children.push(<ReplacedStreamSettings />);
 
     return oldTypeResult;


### PR DESCRIPTION
When selecting any application, screen or capture device in the screen share modal, Discord will crash. This is because props doesn't get checked.